### PR TITLE
refactor: wait longer to create view after creating table

### DIFF
--- a/modules/gcp_bigquery_masked_table/main.tf
+++ b/modules/gcp_bigquery_masked_table/main.tf
@@ -24,7 +24,8 @@ module "table_main" {
 }
 
 resource "time_sleep" "wait_for_table" {
-  create_duration = "10s"
+  create_duration = "60s"
+  depends_on      = [module.table_main]
 }
 
 module "view_masked" {


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* the last merge started failing tests (after the merge somehow), this PR makes the sleep wait 60 seconds and then create the view.
* This PR attempts to fix the broken test on main.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-bigquery/16)
<!-- Reviewable:end -->
