### PR TITLE
ci: disable checkov kms_crypto_key

### DIFF
--- a/modules/gcp_bigquery_dataset/main.tf
+++ b/modules/gcp_bigquery_dataset/main.tf
@@ -26,6 +26,7 @@ resource "google_kms_key_ring" "google_kms_key_ring" {
 
 resource "google_kms_crypto_key" "google_kms_crypto_key" {
   #checkov:skip=CKV_GCP_82:Need to be able to delete because of integration test
+  #checkov:skip=CKV2_GCP_6:Keys are not exported but used in modules
   name            = "${var.name}_${random_id.random_id.hex}"
   key_ring        = google_kms_key_ring.google_kms_key_ring.id
   rotation_period = "7776000s"

--- a/modules/gcp_bigquery_masked_dataset/main.tf
+++ b/modules/gcp_bigquery_masked_dataset/main.tf
@@ -9,6 +9,7 @@ resource "google_kms_key_ring" "google_kms_key_ring" {
 
 resource "google_kms_crypto_key" "google_kms_crypto_key" {
   #checkov:skip=CKV_GCP_82:Need to be able to delete because of integration test
+  #checkov:skip=CKV2_GCP_6:Keys are not exported but used in modules
   name            = "${var.name}-${random_id.random_id.hex}"
   key_ring        = google_kms_key_ring.google_kms_key_ring.id
   rotation_period = "7776000s" # 90 days

--- a/modules/gcp_bigquery_volatile_dataset/main.tf
+++ b/modules/gcp_bigquery_volatile_dataset/main.tf
@@ -26,6 +26,7 @@ resource "google_kms_key_ring" "google_kms_key_ring" {
 
 resource "google_kms_crypto_key" "google_kms_crypto_key" {
   #checkov:skip=CKV_GCP_82:Need to be able to delete because of integration test
+  #checkov:skip=CKV2_GCP_6:Keys are not exported but used in modules
   name            = "${var.name}_${random_id.random_id.hex}"
   key_ring        = google_kms_key_ring.google_kms_key_ring.id
   rotation_period = "7776000s"


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Disable checkov for kms_crypto_key. Checkov is telling that this key should not be public accessible. However, this key is not exported and only used internally within the module.
https://github.com/honestbank/data-warehouse/actions/runs/3529751775/jobs/5921049726
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-bigquery/19)
<!-- Reviewable:end -->
