### PR TITLE
fix: big lake tables with explicit schema [DA-2491]

### DIFF
--- a/examples/gcp_bigquery_big_lake_table/README.md
+++ b/examples/gcp_bigquery_big_lake_table/README.md
@@ -22,6 +22,7 @@
 | <a name="module_big_lake_connection"></a> [big\_lake\_connection](#module\_big\_lake\_connection) | ../../modules/gcp_bigquery_big_lake_connection | n/a |
 | <a name="module_big_lake_table"></a> [big\_lake\_table](#module\_big\_lake\_table) | ../../modules/gcp_bigquery_big_lake_table | n/a |
 | <a name="module_bigquery_dataset"></a> [bigquery\_dataset](#module\_bigquery\_dataset) | ../../modules/gcp_bigquery_dataset | n/a |
+| <a name="module_partitioned_csv_big_lake_table"></a> [partitioned\_csv\_big\_lake\_table](#module\_partitioned\_csv\_big\_lake\_table) | ../../modules/gcp_bigquery_big_lake_table | n/a |
 
 ## Resources
 
@@ -30,6 +31,7 @@
 | [google_service_account.owner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_storage_bucket.big_lake_data_source](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_member.big_lake_connection_gcs_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_object.dummy_csv_file](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.dummy_parquet_file](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [random_id.big_lake_data_source_random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
@@ -49,4 +51,5 @@
 | <a name="output_big_lake_table_link"></a> [big\_lake\_table\_link](#output\_big\_lake\_table\_link) | n/a |
 | <a name="output_bigquery_dataset_id"></a> [bigquery\_dataset\_id](#output\_bigquery\_dataset\_id) | n/a |
 | <a name="output_bigquery_dataset_link"></a> [bigquery\_dataset\_link](#output\_bigquery\_dataset\_link) | n/a |
+| <a name="output_partitioned_csv_big_lake_table_id"></a> [partitioned\_csv\_big\_lake\_table\_id](#output\_partitioned\_csv\_big\_lake\_table\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/gcp_bigquery_big_lake_table/outputs.tf
+++ b/examples/gcp_bigquery_big_lake_table/outputs.tf
@@ -13,3 +13,8 @@ output "big_lake_table_id" {
 output "big_lake_table_link" {
   value = module.big_lake_table.self_link
 }
+
+
+output "partitioned_csv_big_lake_table_id" {
+  value = module.partitioned_csv_big_lake_table.id
+}

--- a/modules/gcp_bigquery_big_lake_table/README.md
+++ b/modules/gcp_bigquery_big_lake_table/README.md
@@ -35,7 +35,7 @@ No modules.
 | <a name="input_hive_source_uri_prefix"></a> [hive\_source\_uri\_prefix](#input\_hive\_source\_uri\_prefix) | A common for all source uris must be required. The prefix must end immediately before the partition key encoding begins | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | A table name for the resource. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_schema"></a> [schema](#input\_schema) | A JSON schema for the table. ~>NOTE: Because this field expects a JSON string, any changes to the string will create a diff, even if the JSON itself hasn't changed. If the API returns a different value for the same schema, e.g. it switched the order of values or replaced STRUCT field type with RECORD field type, we currently cannot suppress the recurring diff this causes. As a workaround, we recommend using the schema as returned by the API. | `string` | `""` | no |
-| <a name="input_source_format"></a> [source\_format](#input\_source\_format) | Source format of table must be NEWLINE\_DELIMITED\_JSON, AVRO or PARQUET | `string` | `"PARQUET"` | no |
+| <a name="input_source_format"></a> [source\_format](#input\_source\_format) | Source format of table must be NEWLINE\_DELIMITED\_JSON, AVRO, PARQUET or CSV | `string` | `"PARQUET"` | no |
 | <a name="input_source_uris"></a> [source\_uris](#input\_source\_uris) | A list of the fully-qualified URIs that point to your data in Google Cloud. https://cloud.google.com/bigquery/docs/external-data-cloud-storage#wildcard-support | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/gcp_bigquery_big_lake_table/main.tf
+++ b/modules/gcp_bigquery_big_lake_table/main.tf
@@ -13,7 +13,7 @@ resource "google_bigquery_table" "google_bigquery_table" {
   table_id            = var.name
 
   # Terraform will detect changes to this property made by BigQuery, but we'll ignore them using the `lifecycle` block.
-  schema = var.schema == "" ? null : var.schema
+  schema = (var.schema == "" || var.connection_id == null) ? null : var.schema
 
   encryption_configuration {
     kms_key_name = var.dataset_kms_key_name
@@ -42,9 +42,12 @@ resource "google_bigquery_table" "google_bigquery_table" {
       source_format = var.source_format
       source_uris   = local.source_uris
 
-      # Use the exact same schema here. This one won't be changed by BigQuery, however Terraform will still detect
-      # intentional changes to this field.
-      schema = var.schema
+      # See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_hive_partitioning_options
+      # If you use external_data_configuration documented below and do not set
+      # external_data_configuration.connection_id, schemas must be specified with
+      # external_data_configuration.schema. Otherwise, schemas must be specified
+      # with this top-level field.
+      schema = var.connection_id == null ? var.schema : null
 
       hive_partitioning_options {
         mode              = var.hive_partitioning_mode

--- a/test/gcp_bigquery_big_lake_table_test.go
+++ b/test/gcp_bigquery_big_lake_table_test.go
@@ -24,6 +24,7 @@ func TestGCPBigQueryBigLakeTable(t *testing.T) {
 
 		assert.NotEmpty(t, id)
 		assert.NotEmpty(t, link)
+		assert.NotEmpty(t, terraform.Output(t, options, "partitioned_csv_big_lake_table_id"))
 
 		// Ensure no drift on next run
 		ensureZeroResourceChange(t, options)


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Fixes a bug that BigLake tables can't be created when schema is explicitly specified.
* Like mentioned [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_hive_partitioning_options), the schema must be defined either in the top-level field or in `external_data_configuration` depending on if `connection_id` is set or not.
* At the moment [Terraform apply fails](https://app.terraform.io/app/honestbank/workspaces/data-warehouse-dev/runs/run-pKmczbB2k3VM5xjj) if the schema is explicitly specified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-bigquery/35)
<!-- Reviewable:end -->
