### PR TITLE
fix: csv_options should be only used when source_format is CSV

### DIFF
--- a/modules/gcp_bigquery_big_lake_table/main.tf
+++ b/modules/gcp_bigquery_big_lake_table/main.tf
@@ -28,6 +28,15 @@ resource "google_bigquery_table" "google_bigquery_table" {
       source_format = var.source_format
       source_uris   = local.source_uris
 
+      dynamic "csv_options" {
+        for_each = var.source_format == "CSV" ? toset(["csv_options"]) : toset([])
+        content {
+          field_delimiter   = var.csv_options.field_delimiter
+          quote             = var.csv_options.quote
+          skip_leading_rows = var.csv_options.skip_leading_rows
+        }
+      }
+
       hive_partitioning_options {
         mode              = var.hive_partitioning_mode
         source_uri_prefix = var.hive_source_uri_prefix
@@ -40,14 +49,18 @@ resource "google_bigquery_table" "google_bigquery_table" {
     content {
       autodetect    = var.autodetect
       connection_id = var.connection_id
-      csv_options {
-        field_delimiter   = var.csv_options.field_delimiter
-        quote             = var.csv_options.quote
-        skip_leading_rows = var.csv_options.skip_leading_rows
-      }
       compression   = var.source_compression
       source_format = var.source_format
       source_uris   = local.source_uris
+
+      dynamic "csv_options" {
+        for_each = var.source_format == "CSV" ? toset(["csv_options"]) : toset([])
+        content {
+          field_delimiter   = var.csv_options.field_delimiter
+          quote             = var.csv_options.quote
+          skip_leading_rows = var.csv_options.skip_leading_rows
+        }
+      }
 
       # See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#nested_hive_partitioning_options
       # If you use external_data_configuration documented below and do not set


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* `csv_options` should be only expected when `source_format` is `CSV`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-bigquery/40)
<!-- Reviewable:end -->
