### PR TITLE
feat: [DEVOP-7627] upgrade Go to 1.26 in terratest modules 

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: 1.26
         id: go
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one does not exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Upgrade Go to 1.26 in the root `go.mod` and update the GitHub Actions terratest workflow to use Go 1.26, ensuring terratest modules are compatible with the latest Go version.